### PR TITLE
Implement FastAPI endpoint filtering by date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # mayak_app
 Web app for sheduling time on tennis court
+
+## Backend API
+
+The backend is built with [FastAPI](https://fastapi.tiangolo.com/). To start the server run:
+
+```bash
+uvicorn backend.server:app --reload
+```
+
+Available endpoints:
+- `GET /occupied?date=YYYY-MM-DD` – returns bookings for the provided date.

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,46 @@
+from fastapi import FastAPI, Depends
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from .db_model.models import Base, Booking
+
+DATABASE_URL = "sqlite:///./data.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+app = FastAPI()
+
+# Create database tables on startup
+Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@app.get("/occupied")
+def get_occupied_slots(date: str | None = None, db: Session = Depends(get_db)):
+    """Return booked slots for the given date."""
+    if date is None:
+        raise HTTPException(status_code=400, detail="date query parameter is required")
+
+    bookings = db.query(Booking).filter(Booking.date == date).all()
+
+    return [
+        {
+            "id": booking.id,
+            "date": booking.date,
+            "time_slot": booking.time_slot,
+            "user_id": booking.user_id,
+            "court_id": booking.court_id,
+        }
+        for booking in bookings
+    ]


### PR DESCRIPTION
## Summary
- update documentation for `/occupied` endpoint usage
- enhance server API to require a `date` query parameter and filter results

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852d0c114f48328b5b8a6e2c0ddde19